### PR TITLE
fix: 修正文档配置和失效链接

### DIFF
--- a/docs/introduction/ides.md
+++ b/docs/introduction/ides.md
@@ -85,7 +85,7 @@ print(sys.version)
 
 #### 解决方法
 
-参考 [about_Execution_Policies](https:/go.microsoft.com/fwlink/?LinkID=135170) 的说明，并更改当前用户的 Powershell 执行策略：
+参考 [about_Execution_Policies](https://go.microsoft.com/fwlink/?LinkID=135170) 的说明，并更改当前用户的 Powershell 执行策略：
 
 ```powershell
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Python 项目工程化开发指南
 
 theme:
   name: material
-  langage: zh
+  language: zh
   features:
   - search.highlight
   - navigation.sections
@@ -29,7 +29,6 @@ markdown_extensions:
 - admonition
 - pymdownx.details
 - pymdownx.superfences
-- pymdownx.tabbed
 - pymdownx.caret
 - pymdownx.mark
 - pymdownx.tilde


### PR DESCRIPTION
## Summary

- 修正 Material for MkDocs 的语言配置键，使中文本地化正确生效
- 移除重复的 `pymdownx.tabbed` 声明，同时保留 `alternate_style: true`
- 修复 PowerShell 执行策略文档的错误链接

## Test plan

- `git diff --check`
- `markdownlint-cli@0.47.0 --config .markdownlint.yml docs/introduction/ides.md`
- `mkdocs build --strict`
- 验证生成页面包含 `<html lang="zh">`
- 验证修复后的 Microsoft 链接返回 HTTP 200