### PR TITLE
ci: modernize documentation workflow

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -1,62 +1,76 @@
-name: gh-page
+name: Documentation
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
-  lint:
-    name: Lint Code Base
+  check:
+    name: Check documentation
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
-          fetch-depth: 0
-      - name: Lint Code Base
-        uses: github/super-linter@v4
-        env:
-          VALIDATE_MARKDOWN: true
-          VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
-          LINTER_RULES_PATH: /
-          MARKDOWN_CONFIG_FILE: .markdownlint.yml
-
-  deploy:
-    name: Deploy
-    needs: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
-          python-version: 3
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
+          config: .markdownlint.yml
+          globs: "**/*.md"
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies
-        run: python3 -m pip install -r ./requirements.txt
+        run: python -m pip install --requirement requirements.txt
 
-      - run: mkdocs build
+      - name: Build documentation
+        run: python -m mkdocs build --strict
+
+  deploy:
+    name: Deploy documentation
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install --requirement requirements.txt
+
+      - name: Build documentation
+        run: python -m mkdocs build --strict
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/docs/practices/web.md
+++ b/docs/practices/web.md
@@ -1949,5 +1949,5 @@ poetry build
 poetry publish
 ```
 
-[^1]: https://www.python.org/doc/sunset-python-2/
+[^1]: <https://www.python.org/doc/sunset-python-2/>
 [^2]: 现在 Anaconda / Miniconda 在 Windows 上使用虚拟环境工具 [Virtualenv](https://virtualenv.pypa.io/en/latest/) 存在一些兼容问题，而且 Pipenv 是依赖这个工具的。请参考 [conda support - Windows 3.7+ #1986](https://github.com/pypa/virtualenv/issues/1986) 和 [virtualenv==20.0.34 not compatible with python on windows #12094](https://github.com/ContinuumIO/anaconda-issues/issues/12094)


### PR DESCRIPTION
## Summary

- replace the legacy Super-Linter setup with focused full-repository Markdown linting
- pin current Actions to immutable commits and use the built-in pip cache from setup-python
- run strict MkDocs checks on branch pushes and pull requests, then deploy only after checks pass on main
- scope repository write permission to the deployment job and serialize gh-pages updates
- convert the one existing bare URL to an autolink so full linting passes

## Validation

- markdownlint-cli2 0.23.2: 30 Markdown files, 0 issues
- MkDocs strict build in a clean Python 3.12 environment
- actionlint 1.7.12
- git diff --check

## Scope

requirements.txt remains unchanged so the existing dependency update in #43 stays independent.