### PR TITLE
docs: use relative internal links

### DIFF
--- a/docs/datadevelop/quick_start/initialization.md
+++ b/docs/datadevelop/quick_start/initialization.md
@@ -13,7 +13,7 @@ cookiecutter https://github.com/pyloong/cookiecutter-pythonic-project-bigdata-et
 
 ## 创建虚拟环境
 
-切换到项目根目录下，项目使用 [poetry](/pythonic-project-guidelines/introduction/virtualenv/#25-poetry)
+切换到项目根目录下，项目使用 [poetry](../../introduction/virtualenv.md#25-poetry)
 管理虚拟环境，运行命令自动创建虚拟环境，同时安装开发环境依赖
 
 ```bash
@@ -50,7 +50,7 @@ poetry install
 
 执行器`executor`，它只关心`AbstractTask`的`run`方法，开发者不需要重复开发调用`Task`相关的功能。
 
-`_load_task`：通过[stevedore](/pythonic-project-guidelines/guidelines/advanced/plugin/#stevedore)
+`_load_task`：通过[stevedore](../../guidelines/advanced/plugin.md#stevedore)
 插件框架，查找在`namespace`中注册的`Task`，并进行实例化。
 
 `run`：调用`AbstractTask`的`run`方法。
@@ -230,7 +230,7 @@ def singleton(cls):
 
 ETL任务完成后需要注册插件：
 
-因为项目默认使用[poetry](/pythonic-project-guidelines/introduction/virtualenv/#25-poetry)
+因为项目默认使用[poetry](../../introduction/virtualenv.md#25-poetry)
 管理虚拟环境，则需要在`pyproject.toml` 文件增加中增加如下内容：
 
 ```toml

--- a/docs/datadevelop/quick_start/preparation.md
+++ b/docs/datadevelop/quick_start/preparation.md
@@ -2,7 +2,7 @@
 
 ## 开发环境
 
-本页总结了数据开发项目所需的准备工作，前提已经完成[开发前准备](/pythonic-project-guidelines/introduction/install)
+本页总结了数据开发项目所需的准备工作，前提已经完成[开发前准备](../../introduction/install.md)
 和安装[Cookiecutter](https://cookiecutter.readthedocs.io/en/1.7.2/README.html)。
 
 快速上手示例项目使用Pyspark进行开发，可以通过[Pypi](https://pypi.org/project/pyspark/)

--- a/docs/datadevelop/quick_start/tests.md
+++ b/docs/datadevelop/quick_start/tests.md
@@ -3,7 +3,7 @@
 ## 单元测试
 
 单元测试（unit test）就是编写测试来验证某一模块的功能正确性。一般会指定输入，验证输出是否符合预期，可以帮助我们很快准确的定位到问题的位置，出现问题的模块和单元。
-我们将使用[Pytest](/pythonic-project-guidelines/guidelines/advanced/test/#12-pytest)进行测试。
+我们将使用[Pytest](../../guidelines/advanced/test.md#12-pytest)进行测试。
 
 ### 配置文件测试
 


### PR DESCRIPTION
## Summary

- replace five internal links that hard-code the /pythonic-project-guidelines/ deployment prefix with source-relative Markdown paths
- preserve the Poetry, Stevedore, and Pytest anchors while allowing MkDocs to resolve them for any deployment base URL
- eliminate all absolute-link diagnostics from the strict MkDocs build

## Validation

- markdownlint-cli2 0.23.2: 30 Markdown files, 0 issues
- MkDocs strict build in a clean Python 3.12 environment with no absolute-link diagnostics
- offline link and fragment check on the three generated pages: 232 links checked, 0 errors
- confirmed no hard-coded internal site-prefix links remain
- git diff --check