### PR TITLE
docs: update stale tooling references

### DIFF
--- a/docs/guidelines/advanced/logging.md
+++ b/docs/guidelines/advanced/logging.md
@@ -269,4 +269,4 @@ def init_yml_log() -> None:
 应该延迟加载。这么做是为了减少在计算日志参数时所消耗的资源，因为如果日志记录非丢弃，则不需要消耗这部分资源。所以在
 日志记录上，应采用 `%` 的方式，而不是其他字符串格式化。
 
-关于性能的讨论可以参考 [W1202 - logging-fstring-interpolation is not useful](https://github.com/PyCQA/pylint/issues/2395) 。
+关于性能的讨论可以参考 [W1202 - logging-fstring-interpolation is not useful](https://github.com/pylint-dev/pylint/issues/2395) 。

--- a/docs/guidelines/project_management/distribution.md
+++ b/docs/guidelines/project_management/distribution.md
@@ -224,7 +224,7 @@ flit build --format wheel
 
 缺点：
 
-- [不支持 CPython 编译](https://github.com/Vlek/roll/issues/29)
+- [扩展模块构建功能仍处于不稳定状态](https://python-poetry.org/docs/building-extension-modules/)
 - 不支持 zip 压缩选项
 
 ##### 2.1.3.1 示例配置


### PR DESCRIPTION
## Summary

- update the Pylint W1202 discussion link to its current pylint-dev repository location
- replace the outdated claim that Poetry cannot build compiled extensions with the current documented limitation: extension-module support exists but remains unstable
- replace the unrelated Roll issue with the official Poetry extension-module documentation

## Validation

- confirmed the Pylint issue title and canonical URL through the GitHub API
- confirmed the Poetry stable documentation explicitly marks extension-module support as unstable
- verified both replacement URLs return HTTP 200
- markdownlint-cli2 0.23.2: 30 Markdown files, 0 issues
- MkDocs strict build in a clean Python 3.12 environment
- confirmed the stale issue references no longer remain
- git diff --check

## References

- https://github.com/pylint-dev/pylint/issues/2395
- https://python-poetry.org/docs/building-extension-modules/