### PR TITLE
docs: remove unavailable sample source links

### DIFF
--- a/docs/guidelines/project_management/distribution.md
+++ b/docs/guidelines/project_management/distribution.md
@@ -3,15 +3,11 @@
 作为项目的最后一环，分发至关重要。有良好的分发流程，便于使用。基于 Python 自带的分发机制显然是
 更好的选择。
 
-本文将以一个数据导出的项目讲述。
+本文以一个将文件数据导入 MongoDB 的项目为例，重点介绍打包分发，因此不展开功能开发。
 
 ## 1. 项目准备
 
-因为本文的重点是对打包分发，所以项目的功能开发就不作为重点。
-
-项目源代码可以在 [pythonic-project-samples](https://github.com/whg517/pythonic-project-samples/tree/example/file2mongo) 中获取。
-
-项目采用 `src` 目录结构，项目描述信息都在 `pyproject.toml` 中定义。
+示例项目名为 `file2mongo`，采用 `src` 目录结构，项目描述信息都在 `pyproject.toml` 中定义。
 
 ## 2. 项目打包
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -2,7 +2,7 @@
 
 这是一个快速上手的开发指南，本文通过一个包含主要知识点的简单项目，向开发者展示一个更符合 Python 规范和风格（Pythonic）的项目开发流程。
 
-示例项目是一个单词统计的演示程序，如果你想查看完整示例，可以浏览 [Word Count](https://github.com/pyloong/pythonic-project-samples/tree/feature/word_count) 项目源码。
+后文将从项目初始化开始，逐步完成一个单词统计演示程序。
 
 ## 1. 开发环境搭建
 


### PR DESCRIPTION
## Summary

- remove the broken Word Count source link and describe the self-contained walkthrough instead
- remove the unavailable `file2mongo` source link while retaining the example name and layout
- clarify that `file2mongo` imports file data into MongoDB

## Rationale

Both linked branches now return 404. The recoverable Word Count history uses Pipenv, `setup.cfg`, and a flat package layout, while the current guide uses Poetry and `src/`; presenting that snapshot as the complete current example would be misleading. No verifiable `file2mongo` source revision remains in the public refs or repository history.

## Validation

- `git diff --check`
- `npx --yes markdownlint-cli2@0.23.2 --config .markdownlint.yml '**/*.md'`\n- clean Python 3.12 environment: `python -m mkdocs build --strict`\n- independent read-only review